### PR TITLE
Replace MD5 hash with expected SHA1 hash.

### DIFF
--- a/files/brews/jmeter.rb
+++ b/files/brews/jmeter.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Jmeter < Formula
   homepage 'http://jmeter.apache.org/'
   url 'http://mirror.tcpdiag.net/apache//jmeter/binaries/apache-jmeter-2.11.tgz'
-  sha1 'f3f853c8f79734580a199efd7a2f0a11'
+  sha1 'e9b24f8b5f34565831aafcb046e72bdfa9537386'
   version '2.11-boxen1'
 
   def install


### PR DESCRIPTION
It looks like the MD5 hash of the file has been used here instead of the SHA1 hash that Homebrew expects, which results in an error:

```
$ boxen --debug
# … time passes ...
Debug: Executing 'brew info boxen/brews/jmeter'
Debug: Executing 'brew boxen-install boxen/brews/jmeter'
Error: Could not update: Execution of 'brew boxen-install boxen/brews/jmeter' returned 1: ==> Downloading http://mirror.tcpdiag.net/apache//jmeter/binaries/apache-jmeter-2.11.tgz
Error: SHA1 mismatch
Expected: f3f853c8f79734580a199efd7a2f0a11
Actual: e9b24f8b5f34565831aafcb046e72bdfa9537386
Archive: /Library/Caches/Homebrew/jmeter-2.11-boxen1.tgz
(To retry an incomplete download, remove the file above.)
# ...
```

Diagnosing:

```
$ md5 /Library/Caches/Homebrew/jmeter-2.11-boxen1.tgz
MD5 (/Library/Caches/Homebrew/jmeter-2.11-boxen1.tgz) = f3f853c8f79734580a199efd7a2f0a11
$ shasum /Library/Caches/Homebrew/jmeter-2.11-boxen1.tgz
e9b24f8b5f34565831aafcb046e72bdfa9537386  /Library/Caches/Homebrew/jmeter-2.11-boxen1.tgz
```
